### PR TITLE
refactor(groupBy): Refactor GroupDurationSubscriber to pass-through to underlying group Subject

### DIFF
--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -227,31 +227,19 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
   constructor(private key: K,
               private group: Subject<T>,
               private parent: GroupBySubscriber<any, K, T>) {
-    super();
+    super(group);
   }
 
   protected _next(value: T): void {
-    this._complete();
+    this.complete();
   }
 
-  protected _error(err: any): void {
-    const group = this.group;
-    if (!group.closed) {
-      group.error(err);
+  protected _unsubscribe() {
+    const { parent, key } = this;
+    this.key = this.parent = null;
+    if (parent) {
+      parent.removeGroup(key);
     }
-    this.parent.removeGroup(this.key);
-    this.unsubscribe();
-    this.parent.remove(this);
-  }
-
-  protected _complete(): void {
-    const group = this.group;
-    if (!group.closed) {
-      group.complete();
-    }
-    this.parent.removeGroup(this.key);
-    this.unsubscribe();
-    this.parent.remove(this);
   }
 }
 


### PR DESCRIPTION
Refactors the GroupDurationSubscriber to be a pass-through for the group Subject. The base implementations of `error` and `complete` already call unsubscribe and remove the subscriber from its parent, so we can rely on those methods. This PR also places the `removeGroup()` call in the `_unsubscribe` method to ensure the group is removed from the parent's Map regardless of how the GroupDurationSubscriber is disposed.